### PR TITLE
Add debug logs for analyze commands

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -112,14 +112,17 @@ async def _analyze_last(update: Update, context: ContextTypes.DEFAULT_TYPE, days
 
 
 async def analyze7(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    logging.info("/analyze7 command received")
     await _analyze_last(update, context, 7)
 
 
 async def analyze14(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    logging.info("/analyze14 command received")
     await _analyze_last(update, context, 14)
 
 
 async def analyze30(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    logging.info("/analyze30 command received")
     await _analyze_last(update, context, 30)
 
 async def main() -> None:


### PR DESCRIPTION
## Summary
- add a log line at the start of each /analyze7, /analyze14 and /analyze30 command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ec0b3548c8332b4c316a723b34bef